### PR TITLE
Add example for skip usage on higher order testing

### DIFF
--- a/skipping-tests.md
+++ b/skipping-tests.md
@@ -36,6 +36,13 @@ it('has home', function () {
 })->skip(true === true, 'Home page not available');
 ```
 
+And it also works with higher order tests:
+```php
+it('works with higher order testing')
+    ->assertTrue(true)
+    ->skip();
+```
+
 <a name="running-single-test"></a>
 ## Running a single test
 


### PR DESCRIPTION
Replacing https://github.com/pestphp/website/pull/96/commits/31ff0d45c60d92111a7314e011f65b90fc66c253