### PR TITLE
Next section link in Coverage skips the Command line page

### DIFF
--- a/coverage.md
+++ b/coverage.md
@@ -48,4 +48,4 @@ for coverage results. If the thresholds are not met, Pest will return failure.
 
 ![Coverage Min](/assets/img/coverage-min.png)
 
-Next section: [PHPUnit →](/docs/guides/phpunit)
+Next section: [Command Line →](/docs/guides/command-line)

--- a/guides/command-line.md
+++ b/guides/command-line.md
@@ -41,3 +41,5 @@ This option allows you to set a minimum required coverage value. If the coverage
 ### `--group`
 
 This option allows you to only run a specific list of [grouped tests](/docs/groups). This is a comma-separated list.
+
+Next section: [PHPUnit →](/docs/guides/phpunit)


### PR DESCRIPTION
Two updates:

1) The 'Next Section' link at the end of the **Coverage** page doesn't move to Command Line page. Instead, it links to the PHPUnit page. It should move to the Command Line page as per the table of contents.

2) In Command Line page, there was no link to the PHPUnit page as continuation. That has been added.