### PR TITLE
Use laravel 8 factory syntax

### DIFF
--- a/guides/laravel.md
+++ b/guides/laravel.md
@@ -133,7 +133,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
 
-beforeEach(fn () => factory(User::class)->create());
+beforeEach(fn () => User::factory()->create());
 
 it('has users')->assertDatabaseHas('users', [
     'id' => 1,


### PR DESCRIPTION
The old docs use `factory(User::class)->create()` helper. I think it should be updated to the latest laravel syntax and use `User::factory()->create()` instead.