### PR TITLE
docs: add page for the Watch plugin

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -21,6 +21,7 @@
 	- [Global Assertions](/docs/plugins/global-assertions)
 	- [Snapshots](/docs/plugins/snapshots)
 	- [Creating Plugins](/docs/plugins/creating-plugins)
+	- [Watch](/docs/plugins/watch)
 - ## More
 	- [Changelog](/docs/changelog)
 	- [Upgrade Guide](/docs/upgrade-guide)

--- a/plugins/creating-plugins.md
+++ b/plugins/creating-plugins.md
@@ -180,4 +180,4 @@ Any amount of further files can be added this way. They will be loaded automatic
 
 ---
 
-Next section: [Changelog →](/docs/changelog/)
+Next section: [Watch Plugin →](/docs/plugins/watch)

--- a/plugins/watch.md
+++ b/plugins/watch.md
@@ -1,0 +1,34 @@
+---
+title: Watch Plugin
+description: The Watch Plugin
+---
+
+# Watch Plugin
+
+> Note: This is still a development package and needs further testing.
+
+The Watch plugin for Pest keeps an eye on your `tests/` folder and automatically run your Pest tests on file change.
+
+Follow these two steps to install it:
+
+1. [**Install fswatch**](https://github.com/emcrisostomo/fswatch#getting-fswatch) on your machine, or check if you already have it:
+
+```bash
+fswatch --version
+```
+
+2. Install the Watch plugin using Composer:
+
+```bash
+composer require pestphp/pest-plugin-watch --dev
+```
+
+This will add a new option to your Pest CLI so you can start watching any updates on your `tests/` folder.
+
+**Just start Pest with the following command:**
+
+```bash
+pest --watch # Night gathers, and now my watch begins
+```
+
+Next section: [Changelog →](/docs/changelog)


### PR DESCRIPTION
This applies the changes from https://github.com/pestphp/website/pull/52 which is now in an archived repository.

I've marked this PR as draft as the plugin isn't ready yet.

I've also marked the 89acfb3c7fd4ca3751ecf91fc528880a8ed51659 commit as co-authored by @caneco and @AlexMartinFR.