### PR TITLE
Fix typo on livewire plugin doc

### DIFF
--- a/plugins/livewire.md
+++ b/plugins/livewire.md
@@ -48,7 +48,7 @@ it('can be decremented', function () {
 });
 ```
 
-Of course, the method `livewire()` can be equaly used in your higher order tests:
+Of course, the method `livewire()` can be equally used in your higher order tests:
 ```php
 it('can be incremented')
     ->livewire(Counter::class)


### PR DESCRIPTION
Hi! This is a simple typo fix on the livewire plugin doc. Thanks for the great test framework!