### PR TITLE
chore: add note about PHP 8 requirement for Mock plugin

### DIFF
--- a/plugins/mock.md
+++ b/plugins/mock.md
@@ -21,6 +21,8 @@ In unit tests, mock objects simulate the behaviour of real objects. They are com
 <a name="installation"></a>
 ### Installation
 
+> **NOTE:** This plugin requires PHP 8 or later due to the use of named parameters.
+
 Install the Mock Plugin via the Composer package manager:
 
 ```bash


### PR DESCRIPTION
Related to https://github.com/pestphp/pest-plugin-mock/pull/3, I think it should be noted that this plugin requires PHP 8 intentionally.