### PR TITLE
Fixing broken links

### DIFF
--- a/assertions.md
+++ b/assertions.md
@@ -39,7 +39,7 @@ it('asserts true is true', function () {
 
 </div>
 
-For the full list of **assertions**, please refer to [PHPUnit Assertions](https://phpunit.readthedocs.io/en/9.0/assertions.html) documentation.
+For the full list of **assertions**, please refer to [PHPUnit Assertions](https://phpunit.readthedocs.io/en/9.5/assertions.html) documentation.
 
 <a name="assertTrue"></a>
 ### `assertTrue()`

--- a/coverage.md
+++ b/coverage.md
@@ -18,7 +18,7 @@ description: Coverage
 
 Code coverage in Pest tells you which lines of code your test
 suite executes and which lines it doesn’t. Of course, PHPUnit
-offers you a beautiful section about this topic: [Code Coverage Analysis](https://phpunit.readthedocs.io/en/9.0/code-coverage-analysis.html).
+offers you a beautiful section about this topic: [Code Coverage Analysis](https://phpunit.readthedocs.io/en/9.5/code-coverage-analysis.html).
 
 > If you're running Xdebug you need to make sure that coverage is enabled in Xdebug. The easiest way to do this is to set the `XDEBUG_MODE` environment
 > variable to `coverage` before running your tests.


### PR DESCRIPTION
Phpunit docs page for 9.0 renders a 404, updated to 9.5

**Note:**  
The file `cli-options.md` links to `phpunit.readthedocs.io/en/latest/`,  however Pest `composer.json` contains `"phpunit/phpunit": ">= 9.3.7 <= 9.5.4"`. Can this generate any sort of confusion or would be best to link everything to `latest`?

Thanks