### PR TITLE
chore[laravel.md]: typo in test/Pest.php

### DIFF
--- a/plugins/laravel.md
+++ b/plugins/laravel.md
@@ -45,7 +45,7 @@ Since Pest is a **progressive testing framework**, your current test suite will 
 <a name="artisan-pest-install"></a>
 ### `pest:install`
 
-The `pest:install` Artisan command creates the `test/Pest.php` file in your tests folder:
+The `pest:install` Artisan command creates the `tests/Pest.php` file in your tests folder:
 
 ```
 php artisan pest:install


### PR DESCRIPTION
In Laravel Plugin, in the pest:install section we found an error where the Pest.php file is located