### PR TITLE
Add Next Section URL in IDE Plugins Page to Exceptions & Errors Page

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -56,4 +56,4 @@ it('redirects to user profile', function () {
 
 ---
 
-Next section: [Exceptions & Errors →](/docs/exceptions-and-errors)
+Next section: [IDE Plugins →](/docs/ide-plugins)

--- a/ide-plugins.md
+++ b/ide-plugins.md
@@ -1,0 +1,3 @@
+---
+
+Next section: [Exceptions & Errors →](/docs/exceptions-and-errors)


### PR DESCRIPTION
I noticed the IDE Plugins Page is different from other pages in the documentation because it lacks the Next Section Button.

I also changed the Next Section URL in the Custom Helpers page to the IDE Plugins Page to improve the reading experience.

This is my first pull request. If there are any mistakes, please forgive me.