### PR TITLE
Adds documentation for skipping the exception type in `throws`

### DIFF
--- a/exceptions-and-errors.md
+++ b/exceptions-and-errors.md
@@ -22,12 +22,21 @@ it('throws exception', function () {
 ```
 
 If you wish to assert the exception message too, you need to give
-a second argument to the `throws` method.
+a second argument to the `throws` method:
 ```php
 it('throws exception', function () {
     throw new Exception('Something happened.');
 })->throws(Exception::class, 'Something happened.');
 ```
+
+If you're only interested in the message, and the exception type
+isn't important, you can just provide the message by itself:
+```php
+it('throws exception', function () {
+    throw new Exception('Something happened.');
+})->throws('Something happened.');
+```
+
 
 ---
 


### PR DESCRIPTION
This documents the following PR:

- https://github.com/pestphp/pest/pull/339