### PR TITLE
Add toBeArray() to list of available expectations

### DIFF
--- a/expectations.md
+++ b/expectations.md
@@ -44,6 +44,7 @@ expect($value)->// chain your checks here
 <div class="collection-method-list" markdown="1">
 
 - [`toBe()`](#expect-toBe)
+- [`toBeArray()`](#expect-toBeArray)
 - [`toBeEmpty()`](#expect-toBeEmpty)
 - [`toBeTrue()`](#expect-toBeTrue)
 - [`toBeFalse()`](#expect-toBeFalse)


### PR DESCRIPTION
Details about the exception are shown, but it's not included in the list of available expectations.