### PR TITLE
update/Typehint returntype `IsValidUrlConstraint()`

### DIFF
--- a/expectations.md
+++ b/expectations.md
@@ -537,7 +537,7 @@ Asserts that the value matches a custom constraint:
 expect('https://google.com')->toMatchConstraint(new IsValidUrlConstraint());
 class IsValidUrlConstraint extends \PHPUnit\Framework\Constraint\Constraint
 {
-    public function toString()
+    public function toString(): string
     {
         return 'is a valid url';
     }


### PR DESCRIPTION
- adds the ":string" typehint to the `IsValidUrlConstraint()`-Constraint example (so it matches the extended `PHPUnit\Framework\Constraint\Constraint::toString()`