### PR TITLE
Add Time plugin

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -22,6 +22,7 @@
 	- [Faker](/docs/plugins/faker)
 	- [Global Assertions](/docs/plugins/global-assertions)
 	- [Snapshots](/docs/plugins/snapshots)
+    - [Time](/docs/plugins/time)
 	- [Watch](/docs/plugins/watch)
 	- [Creating Plugins](/docs/plugins/creating-plugins)
 - ## More

--- a/documentation.md
+++ b/documentation.md
@@ -22,7 +22,7 @@
 	- [Faker](/docs/plugins/faker)
 	- [Global Assertions](/docs/plugins/global-assertions)
 	- [Snapshots](/docs/plugins/snapshots)
-    - [Time](/docs/plugins/time)
+	- [Time](/docs/plugins/time)
 	- [Watch](/docs/plugins/watch)
 	- [Creating Plugins](/docs/plugins/creating-plugins)
 - ## More

--- a/plugins/snapshots.md
+++ b/plugins/snapshots.md
@@ -82,4 +82,4 @@ Also, when you expect a changed value, you may need to run the `-d --update-snap
 
 ---
 
-Next section: [Watch Plugin →](/docs/plugins/watch)
+Next section: [Time Plugin →](/docs/plugins/time)

--- a/plugins/time.md
+++ b/plugins/time.md
@@ -1,0 +1,71 @@
+---
+title: Time Plugin
+description: The Time Plugin
+---
+
+# Snapshots Plugin
+
+- [Overview](#overview)
+- [Installation](#installation)
+- [Usage](#usage)
+
+<a name="overview"></a>
+## Overview
+
+The Time Plugin for Pest allows you to control the flow of time in your Pest tests. This plugin assumes you're using [Carbon](https://carbon.nesbot.com) to handle date and time in your app.
+
+**Source code**: [github.com/spatie/pest-plugin-test-time](https://github.com/spatie/pest-plugin-test-time)
+
+<a name="installation"></a>
+### Installation
+
+Install the Time Plugin via the Composer package manager:
+
+```bash
+composer require spatie/pest-plugin-test-time --dev
+```
+
+<a name="usage"></a>
+## Usage
+
+You can call `freeze` on the `testTime` function to freeze the current time.
+
+```php
+use Carbon\Carbon;
+use function Spatie\PestPluginTestTime\testTime;
+
+testTime()->freeze(); // the current time will not change anymore
+
+Carbon::now(); // returns the time
+
+sleep(2);
+
+Carbon::now(); // will return the same time as above
+```
+
+### Freezing at a specific point in time
+
+You can also freeze the time at a specific point by passing the time in format `Y-m-d H:i:s`.
+
+```php
+testTime()->freeze('2021-01-02 12:34:56');
+
+\Carbon\Carbon::now()->format('Y-m-d H:i:s') // returns '2021-01-02 12:34:56';
+```
+
+## Changing the time
+
+You can change the time, by calling any of the `add` and `sub` functions that are available on `Carbon`.
+
+```php
+testTime()->freeze('2021-01-02 12:34:56');
+
+testTime()->addHour(); // time is now at '2021-01-02 13:34:56'
+
+// you can even chain method calls
+testTime()->subMinute()->addSeconds(2); // time is now at '2021-01-02 13:33:58'
+```
+
+---
+
+Next section: [Watch Plugin →](/docs/plugins/watch)


### PR DESCRIPTION
This PR adds the docs for Time plugin: https://github.com/spatie/pest-plugin-test-time 

I did not find where the menu structure of https://pestphp.com/docs is being managed, so that one needs to be updated as well. 