### PR TITLE
Adds money plugin to sidebar

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -18,6 +18,7 @@
 	- [Laravel](/docs/plugins/laravel)
 	- [Livewire](/docs/plugins/livewire)
 	- [Mock](/docs/plugins/mock)
+  	- [Money](/docs/plugins/money)
 	- [Mutation Testing](/docs/plugins/mutation-testing)
 	- [Faker](/docs/plugins/faker)
 	- [Global Assertions](/docs/plugins/global-assertions)


### PR DESCRIPTION
Me again,

didn't quite twig how the sidebar loaded the items and forgot to add the money plugin to the sidebar.

This fixes that.