### PR TITLE
Updates expect()->toContain() docs

### DIFF
--- a/expectations.md
+++ b/expectations.md
@@ -170,12 +170,13 @@ expect($count)->toBeLessThanOrEqual(2);
 ```
 
 <a name="expect-toContain"></a>
-### `toContain($needle)`
+### `toContain($needles)`
 
-Asserts that the needle is an element of the value:
+Asserts that all given needles are elements of the value:
 
 ```php
-expect($content)->toContain('Hello World');
+expect("Hello World")->toContain('Hello');
+expect([1, 2, 3, 4])->toContain(2, 4);
 ```
 
 <a name="expect-toHaveCount"></a>


### PR DESCRIPTION
this PR will update docs to clarify the ability to use multiple needles in `toContain()` expectation

ref [#365](https://github.com/pestphp/pest/pull/365)