### PR TITLE
Update instructions for running Dusk tests

### DIFF
--- a/plugins/laravel.md
+++ b/plugins/laravel.md
@@ -222,7 +222,7 @@ it('has homepage', function () {
 
 > **Note:** You can still use Dusk's regular class-based syntax as you can do with any other tests.
 
-Now, when you run `pest` you will see your Dusk tests as well.
+Now, you can run your Dusk tests via `php artisan pest:dusk`.
 
 > **Note:** As for now, the Laravel plugin doesn't support Dusk's functions, so you'll have to use them with the `$this` variable as the example above shows.
 


### PR DESCRIPTION
Currently, if you run pest via `./vendor/bin/pest` or `php artisan test` it does not execute the Dusk tests. 

I've updated the docs to reflect this. This is an issue I ran into that had me confused for quite some time.