### PR TITLE
Fix `->only()` link leading to 404.

### DIFF
--- a/cli-options.md
+++ b/cli-options.md
@@ -47,7 +47,7 @@ This option allows you to specify the directory that will be used to gather the 
 
 ### `--ci`
 
-You may use the `--ci` option to instruct Pest that the test suite is running within a Continuous Integration environment. When provided, this option makes Pest ignore development/local features such as [->only()](docs/skipping-tests#running-single-test).
+You may use the `--ci` option to instruct Pest that the test suite is running within a Continuous Integration environment. When provided, this option makes Pest ignore development/local features such as [->only()](/docs/skipping-tests#running-single-test).
 
 ---
 


### PR DESCRIPTION
Currently the `->only()` link in **CLI Options** `--ci` is leading to a 404, this PR fixes that by adding the missing `/` in front of the relative URL like all other relative links have.

### Screenshot of issue.

![Screen Shot 2021-11-01 at 12 43 39 PM](https://user-images.githubusercontent.com/2221746/139666504-ae52f306-a8d7-4b03-911c-3caae87fd0c8.png)

