### PR TITLE
Fix typo in calling `->once` method

### DIFF
--- a/plugins/mock.md
+++ b/plugins/mock.md
@@ -63,7 +63,7 @@ Of course, while the `expect(callable ...$methods)` method addresses most of the
 test('some service', function () {
     $mock = mock(UserRepository::class)
         ->shouldReceive('save')
-        ->once
+        ->once()
         ->andReturn(true);
 
     expect($mock->save('Nuno'))->toBeTrue();


### PR DESCRIPTION
Calling `->once` causes an exception when running tests. It should be called with parenthesis as `->once()`