### PR TITLE
Update docs to include exclude-group

### DIFF
--- a/cli-options.md
+++ b/cli-options.md
@@ -41,6 +41,10 @@ This option allows you to set a minimum required coverage value. If the coverage
 
 This option allows you to only run a specific list of [grouped tests](/docs/groups). This is a comma-separated list.
 
+### `--exclude-group`
+
+You may also use the `--exclude-group` option to instruct Pest to exclude [grouped tests](/docs/groups). This is a comma-separated list.
+
 ### `--test-directory`
 
 This option allows you to specify the directory that will be used to gather the tests that should be run. If it isn't provided the default `tests` directory will be used.

--- a/groups.md
+++ b/groups.md
@@ -47,6 +47,12 @@ running Pest on the command-line:
 ./vendor/bin/pest --group=integration,browser
 ```
 
+You may also exclude specific groups using the  `--exclude-group` option:
+
+```bash
+./vendor/bin/pest --exclude-group=api
+```
+
 > **Note:** The `uses()->group('integration')->in('Feature')` will **not** put any PHPUnit test class under the *integration* group.
 You still need the `@group` [annotation](https://phpunit.readthedocs.io/en/latest/annotations.html) for them.
 Pest will understand it.


### PR DESCRIPTION
A simple PR to mention `exclude-group` in the [CLI Options](https://pestphp.com/docs/cli-options) and [Groups Of Tests](https://pestphp.com/docs/groups) pages.