### PR TITLE
Correct small issues in the mock documentation

### DIFF
--- a/plugins/mock.md
+++ b/plugins/mock.md
@@ -63,8 +63,8 @@ Of course, while the `expect(callable ...$methods)` method addresses most of the
 test('some service', function () {
     $mock = mock(UserRepository::class)
         ->shouldReceive('save')
-        ->once()
-        ->andReturn(true);
+        ->andReturn(true)
+        ->getMock();
 
     expect($mock->save('Nuno'))->toBeTrue();
 });


### PR DESCRIPTION
Attempting to use the second mock example, as described, results in two errors:

`call_user_func_array(): Argument #1 ($callback) must be a valid callback, class Mockery\Expectation does not have a method "isSet"`

This is because, as described, an `ExpectationInterface` object is returned, not a `MockInterface` object.

`Method isSet(<Any Arguments>) from Mockery_0_WeatherStation_Service_WeatherService should be called exactly
1 times but called 0 times.`

This is because of using `once()`.

I suggest the fix in this commit to correct both issues. I appreciate it's an arbitrary example, but I feel that this will help.