### PR TITLE
Use HTTPS for external URL

### DIFF
--- a/plugins/mock.md
+++ b/plugins/mock.md
@@ -70,7 +70,7 @@ test('some service', function () {
 });
 ```
 
-For the full list of available methods, please refer to the **[Mockery documentation](http://docs.mockery.io/en/latest/)**.
+For the full list of available methods, please refer to the **[Mockery documentation](https://docs.mockery.io/en/latest/)**.
 
 ---
 


### PR DESCRIPTION
We should be linking to the HTTPS versions of websites where possible.