### PR TITLE
Corrects error in sequence expectation example

### DIFF
--- a/expectations.md
+++ b/expectations.md
@@ -782,7 +782,7 @@ the first argument, and the key as an expectation for the second argument:
 
 ```php
 expect(['hello' => 'world', 'foo' => 'bar', 'john' => 'doe'])->sequence(
-    fn ($value, $key) => $value->toEqual('hello'),
+    fn ($value, $key) => $value->toEqual('world'),
     fn ($value, $key) => $key->toEqual('foo'),
     fn ($value, $key) => $value->toBeString(),
 );


### PR DESCRIPTION
The 'hello' => 'world' associative iterable [sequence expectation example](https://pestphp.com/docs/expectations#sequence) has the key 'hello' in the expectation instead of the value 'world'.