### PR TITLE
Update installation.md

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -79,4 +79,4 @@ The image below shows the default Test output in a brand-new project:
 
 ---
 
-**Next**: In the next section, we are going to learn how to write tests with Pest: [Writing Tests →](docs/writing-tests)
+**Next**: In the next section, we are going to learn how to write tests with Pest: [Writing Tests →](/docs/writing-tests)


### PR DESCRIPTION
Use absolute link instead of relative link for the "next page" link. 

This was causing a 404 in the doc when using the link at the bottom of the page due to having two times "docs" in the URL.