### PR TITLE
Fix next section link in creating plugins page

### DIFF
--- a/plugins/creating-plugins.md
+++ b/plugins/creating-plugins.md
@@ -180,4 +180,4 @@ Any amount of further files can be added this way. They will be loaded automatic
 
 ---
 
-Next section: [Changelog →](/docs/changelog)
+Next section: [Support Policy →](/docs/support-policy)


### PR DESCRIPTION
Changelog, where the link was pointing, is not present anymore. Linking to the next menu item - Support Policy - instead.

If that's the expected behaviour then it...

Fixes #147 