### PR TITLE
Add link to `fswatch` in Watch plugin

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -155,7 +155,9 @@ To install Pest's "watch" plugin, you need to require the plugin via Composer.
 composer require pestphp/pest-plugin-watch --dev
 ```
 
-After installing the plugin, you will be able to use the `--watch` option when running Pest. This option instructs Pest to monitor your application and automatically re-run your tests when you change files within a list of specified directories.
+Make sure you also install [`fswatch`](https://github.com/emcrisostomo/fswatch#getting-fswatch) so Pest can monitor when a file changes.
+
+Once both the plugin and `fswatch` are installed, you will be able to use the `--watch` option when running Pest. This option instructs Pest to monitor your application and automatically re-run your tests when you change files within a list of specified directories.
 
 ```bash
 pest --watch


### PR DESCRIPTION
This add the installation of `fswatch` to the installation process.

When running `--watch` for the first time and having the [error message](https://github.com/pestphp/pest-plugin-watch/blob/fce573f06a39ff2114dfc0fe5abd40b3c456401d/src/Plugin.php#L113-L120), I wondered if I did something wrong or if there was a bug. Only after `fswatch` installation and running it again, came the relief. 😌

The plugin seems to work well at first sight, so many thanks. It’s very useful!