### PR TITLE
Small general fixes

### DIFF
--- a/custom-expectations.md
+++ b/custom-expectations.md
@@ -87,7 +87,7 @@ expect()->intercept('toBe', fn (mixed $value) => is_string($value), function (st
 
 ## Pipe Expectations
 
-There may be instances where you want to run one of Pest's built-in expectations, but include customized expectation logic under certain conditions. In these cases, you can use the `pipe` method. For example, we may want to customize the behavior of the `toBe()` expectation if the given value is an Eloquent model.
+There may be instances where you want to run one of Pest's built-in expectations, but include customized expectation logic under certain conditions. In these cases, you can use the `pipe()` method. For example, we may want to customize the behavior of the `toBe()` expectation if the given value is an Eloquent model.
 
 ```php
 use Illuminate\Database\Eloquent\Model;

--- a/custom-helpers.md
+++ b/custom-helpers.md
@@ -7,7 +7,7 @@ description: If you're transitioning to a functional approach for writing tests,
 
 If you're transitioning to a functional approach for writing tests, you may wonder where to put your helpers that used to be protected or private methods in your test classes. When using Pest, these helper methods should be converted to simple functions.
 
-For example, if your helper is specific to a certain test file, you may create the helper in the test file directly. Within your helper, you may invoke the `test` function to access the test class instance that would normally be available via `$this`.
+For example, if your helper is specific to a certain test file, you may create the helper in the test file directly. Within your helper, you may invoke the `test()` function to access the test class instance that would normally be available via `$this`.
 
 ```php
 use App\Models\User;

--- a/exceptions.md
+++ b/exceptions.md
@@ -29,7 +29,7 @@ it('throws exception', function () {
 })->throws('Something happened.');
 ```
 
-You can use the `throwsIf` method to conditionally verify an exception if a given boolean expression evaluates to true.
+You can use the `throwsIf()` method to conditionally verify an exception if a given boolean expression evaluates to true.
 
 ```php
 it('throws exception', function () {

--- a/exceptions.md
+++ b/exceptions.md
@@ -1,11 +1,11 @@
 ---
 title: Exceptions
-description: When testing behavior in PHP, you might need to check if an exception or error has been thrown. To create a test that expects an exception to be thrown, you can use the `throws` method.
+description: When testing behavior in PHP, you might need to check if an exception or error has been thrown. To create a test that expects an exception to be thrown, you can use the `throws()` method.
 ---
 
 # Exceptions
 
-When testing behavior in PHP, you might need to check if an exception or error has been thrown. To create a test that expects an exception to be thrown, you can use the `throws` method.
+When testing behavior in PHP, you might need to check if an exception or error has been thrown. To create a test that expects an exception to be thrown, you can use the `throws()` method.
 
 ```php
 it('throws exception', function () {
@@ -13,7 +13,7 @@ it('throws exception', function () {
 })->throws(Exception::class);
 ```
 
-If you also want to make an assertion against the exception message, you may provide a second argument to the `throws` method.
+If you also want to make an assertion against the exception message, you may provide a second argument to the `throws()` method.
 
 ```php
 it('throws exception', function () {

--- a/expectations.md
+++ b/expectations.md
@@ -7,7 +7,7 @@ description: By setting expectations for your tests using the Pest expectation A
 
 By setting expectations for your tests using the Pest expectation API, you can easily identify bugs and other issues in your code. This is because the API allows you to specify the expected outcome of a test, making it easy to detect any deviations from the expected behavior.
 
-You can start the expectation by passing your value to the `expect($value)` function. The `expect` function is used every time you want to test a value. You will rarely call `expect` by itself. Instead, you will use `expect` along with an "expectation" method to assert something about the value.
+You can start the expectation by passing your value to the `expect($value)` function. The `expect()` function is used every time you want to test a value. You will rarely call `expect()` by itself. Instead, you will use `expect()` along with an "expectation" method to assert something about the value.
 
 ```php
 test('sum', function () {

--- a/filtering-tests.md
+++ b/filtering-tests.md
@@ -86,7 +86,7 @@ The `--retry` flag reorders your test suites by prioritizing the previously fail
 <a name="only"></a>
 ### `only()`
 
-If you want to run a specific test in your test suite, you can use the `only` method.
+If you want to run a specific test in your test suite, you can use the `only()` method.
 
 ```bash
 test('sum', function () {

--- a/grouping-tests.md
+++ b/grouping-tests.md
@@ -1,11 +1,11 @@
 ---
 title: Grouping Tests
-description: You can assign tests folders to various groups using Pest's `group` method. Assigning a group to a set of relatively slow tests could be beneficial since it allows you to selectively execute them separately from the rest of your test suite. Typically, the process of assigning a set of tests to a group is done within your `Pest.php` configuration file.
+description: You can assign tests folders to various groups using Pest's `group()` method. Assigning a group to a set of relatively slow tests could be beneficial since it allows you to selectively execute them separately from the rest of your test suite. Typically, the process of assigning a set of tests to a group is done within your `Pest.php` configuration file.
 ---
 
 # Grouping Tests
 
-You can assign tests folders to various groups using Pest's `group` method. Assigning a group to a set of relatively slow tests could be beneficial since it allows you to selectively execute them separately from the rest of your test suite. Typically, the process of assigning a set of tests to a group is done within your `Pest.php` configuration file.
+You can assign tests folders to various groups using Pest's `group()` method. Assigning a group to a set of relatively slow tests could be beneficial since it allows you to selectively execute them separately from the rest of your test suite. Typically, the process of assigning a set of tests to a group is done within your `Pest.php` configuration file.
 
 For instance, consider the scenario where we assign the tests located in the `tests/Feature` folder to a group named "feature".
 

--- a/higher-order-testing.md
+++ b/higher-order-testing.md
@@ -78,7 +78,7 @@ it('validates emails')
     ->toBeTrue();
 ```
 
-# Higher Order Expectations
+## Higher Order Expectations
 
 With Higher Order Expectations, you can perform expectations directly on the `properties` or `methods` of the expectation `$value`.
 
@@ -126,7 +126,7 @@ expect(['name' => 'Nuno', 'projects' => ['Pest', 'OpenAI', 'Laravel Zero']])
     );
 ```
 
-# Scoped Higher Order Expectations
+## Scoped Higher Order Expectations
 
 With Scoped Higher Order Expectations, you may use the method `scoped()` and a closure to gain access and lock an expectation in to a certain level in the chain.
 

--- a/higher-order-testing.md
+++ b/higher-order-testing.md
@@ -48,7 +48,7 @@ it('has a name')
 
 It is crucial to use lazy evaluation for the expectation value by passing a closure to the `expect()` method. This ensures that the expected value is created only when the test runs and not before.
 
-If you need to make assertions on an object that requires lazy evaluation at runtime, you can use the `defer` method.
+If you need to make assertions on an object that requires lazy evaluation at runtime, you can use the `defer()` method.
 
 ```php
 it('creates admins')
@@ -56,7 +56,7 @@ it('creates admins')
     ->assertDatabaseHas('users', ['id' => 1]);
 ```
 
-In the example above, the `assertDatabaseHas` assertion method will be called on the result of the closure passed to the `defer` method.
+In the example above, the `assertDatabaseHas()` assertion method will be called on the result of the closure passed to the `defer()` method.
 
 The principles of high-order testing can also be applied to hooks. This means that if the body of your hook consists of a sequence of methods chained to the `$this` variable, you can simply chain those methods to the hook method and omit the closure entirely.
 

--- a/mocking.md
+++ b/mocking.md
@@ -21,7 +21,7 @@ While comprehensive documentation for Mockery can be found on the [Mockery websi
 
 ## Method Expectations
 
-Mock objects are essential for isolating the code being tested and simulating specific behaviors or conditions from other pieces of the application. After creating a mock using the `Mockery::mock()` method, we can indicate that we expect a certain method to be invoked by calling the `shouldReceive` method.
+Mock objects are essential for isolating the code being tested and simulating specific behaviors or conditions from other pieces of the application. After creating a mock using the `Mockery::mock()` method, we can indicate that we expect a certain method to be invoked by calling the `shouldReceive()` method.
 
 ```php
 use App\Repositories\BookRepository;

--- a/skipping-tests.md
+++ b/skipping-tests.md
@@ -1,11 +1,11 @@
 ---
 title: Skipping Tests
-description: During the development process, there may be times when you need to temporarily disable a test. Rather than commenting out the code, we recommended using the `skip` method.
+description: During the development process, there may be times when you need to temporarily disable a test. Rather than commenting out the code, we recommended using the `skip()` method.
 ---
 
 # Skipping Tests
 
-During the development process, there may be times when you need to temporarily disable a test. Rather than commenting out the code, we recommended using the `skip` method.
+During the development process, there may be times when you need to temporarily disable a test. Rather than commenting out the code, we recommended using the `skip()` method.
 
 ```php
 it('has home', function () {

--- a/upgrade-guide.md
+++ b/upgrade-guide.md
@@ -98,7 +98,7 @@ Pest 2 is built on top of PHPUnit 10. This means that any notable changes made t
 
 > Likelihood Of Impact: Low
 
-When performing high order testing, you might have utilized the `tap` method to invoke assertions on an object that needs lazy evaluation during runtime. With Pest 2, the `tap` method is deprecated. Instead, you should use the `defer` method.
+When performing high order testing, you might have utilized the `tap()` method to invoke assertions on an object that needs lazy evaluation during runtime. With Pest 2, the `tap()` method is deprecated. Instead, you should use the `defer()` method.
 
 ```diff
 it('creates admins')

--- a/writing-tests.md
+++ b/writing-tests.md
@@ -42,7 +42,7 @@ After writing your test code, it's time to run your tests using Pest. When you e
     <img src="/assets/img/sum.webp?1" style="--lines: 5" />
 </div>
 
-As an alternative to the `test` function, Pest provides the convenient `it` function that simply prefixes the test description with the word "it", making your tests more readable.
+As an alternative to the `test()` function, Pest provides the convenient `it()` function that simply prefixes the test description with the word "it", making your tests more readable.
 
 ```php
 it('performs sums', function () {

--- a/writing-tests.md
+++ b/writing-tests.md
@@ -62,7 +62,7 @@ In this case, when you run the `./vendor/bin/pest` command, the output will incl
 
 As you may have noticed in our previous examples, we made use of Pest's expectation API to perform assertions in our test code. The `expect()` function is a core part of the expectation API and is used to assert that certain conditions are met.
 
-For instance, in our previous example, we used `expect($result)->toBe(3)` to ensure that the value of `$result` is equal to `3`. Pest's expectation API provides a variety of other assertion functions that you can use to test the behavior of your code, such as `toBeTrue`, `toBeFalse`, and `toContain`.
+For instance, in our previous example, we used `expect($result)->toBe(3)` to ensure that the value of `$result` is equal to `3`. Pest's expectation API provides a variety of other assertion functions that you can use to test the behavior of your code, such as `toBeTrue()`, `toBeFalse()`, and `toContain()`.
 
 By using the expectation API, you can write concise and readable assertions that make it clear what your code is doing and how it should behave. In the [next section](/docs/expectations), we will cover some of the most commonly used assertion functions in Pest's expectation API.
 

--- a/writing-tests.md
+++ b/writing-tests.md
@@ -60,7 +60,7 @@ In this case, when you run the `./vendor/bin/pest` command, the output will incl
 
 ## Expectation API
 
-As you may have noticed in our previous examples, we made use of Pest's expectation API to perform assertions in our test code. The `expect` function is a core part of the expectation API and is used to assert that certain conditions are met.
+As you may have noticed in our previous examples, we made use of Pest's expectation API to perform assertions in our test code. The `expect()` function is a core part of the expectation API and is used to assert that certain conditions are met.
 
 For instance, in our previous example, we used `expect($result)->toBe(3)` to ensure that the value of `$result` is equal to `3`. Pest's expectation API provides a variety of other assertion functions that you can use to test the behavior of your code, such as `toBeTrue`, `toBeFalse`, and `toContain`.
 


### PR DESCRIPTION
This PR fixes the heading on `Higher Order Testing` and corrects inconsistencies when writing about functions and methods. 

We can find both usages: "use the method **foo()** to..." and "use the method **foo** to...".

For example:

```plain
It is important to remember that the it() function prefixes [...]
As an alternative to the test function, Pest provides the convenient it function that [...]
```

```plain
[...] you can use to test the behavior of your code, such as toBeTrue [...]
[...] you can replace the toBe() expectation to check [...]
```
In this PR, I've changed all the occurrences to the `foo()` style, which appears most often in the documentation. 

Adopting and following this visual consistency makes the documentation easier for beginners.
