### PR TITLE
Update `cli-reference.md` to remove reference to `--process-isolation` option.

### DIFF
--- a/cli-api-reference.md
+++ b/cli-api-reference.md
@@ -37,7 +37,6 @@ In the preceding chapters of the Pest documentation, we have covered numerous CL
 
 ## Execution
 
-- `--process-isolation`: Run each test in a separate PHP process.
 - `--globals-backup`: Backup and restore $GLOBALS for each test.
 - `--static-backup`: Backup and restore static properties for each test.
 - `--strict-coverage`: Be strict about code coverage metadata.


### PR DESCRIPTION
`--process-isolation` option isn't supported but it's listed in the docs which could be a bit confusing.

There is technically a handler for it in the code but it just returns an error to say its not supported.

Alternatively we could add a note in the docs to say explicitly its not supported?

<img width="444" alt="image" src="https://user-images.githubusercontent.com/2048674/227781443-d355e8d3-4f30-428b-9a1f-4e178ea9ba71.png">

See:
 https://github.com/pestphp/pest/issues/618