### PR TITLE
Snapshot plugin link and update improvement on parallel test

### DIFF
--- a/announcing-pest2.md
+++ b/announcing-pest2.md
@@ -16,7 +16,7 @@ Today we’re finally making the long-awaited release of Pest 2.0! Our creator i
 Pest 2.0 marks a major milestone in our development, packed with an array of powerful features such as:
 
 - **[Powerful Architecture Plugin](/docs/arch-testing)**, for testing the architectural rules of your application with ease
-- **[Up To 60% Speed Improvements on "--parallel" testing](/docs/optimizing-tests#parallel)**, with our fully rewritten parallel core, enjoy significantly faster test runs
+- **[Up To 80% Speed Improvements on "--parallel" testing](/docs/optimizing-tests#parallel)**, with our fully rewritten parallel core, enjoy significantly faster test runs
 - **[--profile option](/docs/optimizing-tests#content-profiling)**, to identify the slowest tests and optimize their execution
 - **[--compact printer](/docs/optimizing-tests#content-compact-printer)**, a minimal printer that only outputs information about test failures
 - **[--retry option](/docs/filtering-tests#retry)**, for saving time by running only previously unsuccessful tests

--- a/why-pest.md
+++ b/why-pest.md
@@ -7,7 +7,6 @@ description: When testing PHP code, you have access to a range of frameworks. Ne
 
 When testing PHP code, you have access to a range of frameworks. Nevertheless, we believe that Pest is the most elegant and sophisticated testing framework in the world. It's designed to make the testing process enjoyable, and our goal is to make tests easy to read and understand, with a code syntax that closely resembles natural human language.
 
-
 ```php
 function sum($a, $b) {
     return $a + $b;
@@ -34,7 +33,7 @@ In addition to its exceptional test reporting, Pest also offers a range of other
 - Native [profiling tools](/docs/optimizing-tests#profiling) to optimize slow-running tests
 - Out-of-the-box [Architectural Testing](/docs/arch-testing) to test application rules
 - [Coverage](/docs/test-coverage) report directly on the terminal to track code coverage
-- Dozens of [optional plugins](/docs/plugins), such as Watch Mode and Snapshot testing to customize Pest to fit your needs.
+- Dozens of [optional plugins](/docs/plugins), such as Watch Mode and [Snapshot testing](https://github.com/spatie/pest-plugin-snapshots), to customize Pest to fit your needs.
 
 Whether you're engaged in a small personal project or a large-scale enterprise application, Pest has got you covered. So if you want to make the testing process enjoyable and efficient, give Pest a try. We're confident that you'll love it as much as we do.
 


### PR DESCRIPTION
This PR adds the missing link to Spatie's Snapshot plugin and updates the figure on parallel test improvement.