### PR TITLE
Add toThrow(new Exception('message')) to docs

### DIFF
--- a/expectations.md
+++ b/expectations.md
@@ -631,6 +631,7 @@ This expectation ensures that a closure throws a specific exception class, excep
 expect(fn() => throw new Exception('Something happened.'))->toThrow(Exception::class);
 expect(fn() => throw new Exception('Something happened.'))->toThrow('Something happened.');
 expect(fn() => throw new Exception('Something happened.'))->toThrow(Exception::class, 'Something happened.');
+expect(fn() => throw new Exception('Something happened.'))->toThrow(new Exception('Something happened'));
 ```
 
 <a name="expect-toMatch"></a>


### PR DESCRIPTION
This PR will add a new example for `toThrow()` including the new check implemented in https://github.com/pestphp/pest/pull/797