### PR TITLE
Change returned type User to TestCase

### DIFF
--- a/custom-helpers.md
+++ b/custom-helpers.md
@@ -11,8 +11,9 @@ For example, if your helper is specific to a certain test file, you may create t
 
 ```php
 use App\Models\User;
+use Tests\TestCase;
 
-function asAdmin(): User
+function asAdmin(): TestCase
 {
     $user = User::factory()->create([
         'admin' => true,


### PR DESCRIPTION
Hi,
I'm using the custom helpers and noticed that the return type was TestCase and not User. Since the change the tests work again.

TestCase type come from to raw 13:
[](https://github.com/pestphp/pest-plugin-laravel/blob/2.x/src/Authentication.php)

Continue like that, Pest are amazing ! 