### PR TITLE
Add documentation for glob patterns in ->in() method

### DIFF
--- a/configuring-tests.md
+++ b/configuring-tests.md
@@ -29,6 +29,27 @@ it('has home', function () {
 });
 ```
 
+Additionally, Pest supports [glob patterns](https://www.php.net/manual/en/function.glob.php) in the in() method. This allows you to specify multiple directories or files with a single pattern. Glob patterns are string representations that can match various file paths, like wildcards. If you are unfamiliar with glob patterns, refer to the PHP manual [here](https://www.php.net/manual/en/function.glob.php).
+
+```php
+// tests/Pest.php
+uses(Tests\TestCase::class)->in('Feature/*Job*.php');
+
+// This will apply the Tests\TestCase to all test files in the "Feature" directory that contains "Job" in their filename.
+```
+
+Another more complex example would be using a pattern to match multiple directories in different modules while applying multiple test case classes and traits:
+
+```php
+// tests/Pest.php
+uses(
+    DuskTestCase::class,
+    DatabaseMigrations::class
+)->in('../Modules/*/Tests/Browser');
+
+// This will apply the DuskTestCase class and the DatabaseMigrations trait to all test files within any module's "Browser" directory.
+```
+
 Any method that is defined as `public` or `protected` in your base test case class can be accessed within the test closure.
 
 ```php


### PR DESCRIPTION
This commit adds documentation for the recently merged feature that allows the use of PHP glob patterns in the `->in()` method. This feature was introduced in the following pull request:

- [Pull Request #829](https://github.com/pestphp/pest/pull/829)

The new documentation explains how to use glob patterns in Pest's configuration file to specify multiple directories or files with a single pattern and provides examples for better understanding:

1. Applying a base test case class to all test files in a directory that match a specific pattern:

```php
// tests/Pest.php
uses(Tests\TestCase::class)->in('Feature/*Job*.php');
```
2. Using a glob pattern to match multiple directories in different modules while applying multiple test case classes and traits:
```php
// tests/Pest.php
uses(
    DuskTestCase::class,
    DatabaseMigrations::class
)->in('../Modules/*/Tests/Browser');
```