### PR TITLE
Fix broken link to Scoped Datasets

### DIFF
--- a/upgrade-guide.md
+++ b/upgrade-guide.md
@@ -130,7 +130,7 @@ If you are utilizing "bound" datasets and binding a single dataset argument, you
 
 > Likelihood Of Impact: Very low
 
-Although we previously documented in Pest 1 that datasets should only be declared using the `dataset` function in the `tests/Pest.php` or `tests/Datasets.php` files, you could actually declare datasets in any test file within your test suite. However, in Pest 2, with the introduction of [scoped datasets](/docs/datasets#scoped-datasets), datasets declared in a test file can only be utilized within that same test file. Therefore, if you have a dataset that needs to be accessible globally, please ensure that it is placed in either the `tests/Pest.php` or `tests/Datasets.php` files.
+Although we previously documented in Pest 1 that datasets should only be declared using the `dataset` function in the `tests/Pest.php` or `tests/Datasets.php` files, you could actually declare datasets in any test file within your test suite. However, in Pest 2, with the introduction of [scoped datasets](/docs/datasets#content-scoped-datasets), datasets declared in a test file can only be utilized within that same test file. Therefore, if you have a dataset that needs to be accessible globally, please ensure that it is placed in either the `tests/Pest.php` or `tests/Datasets.php` files.
 
 ---
 


### PR DESCRIPTION
Just trying to debug an issue with Scoped Datasets and the URL on the upgrade guide references an invalid element ID for the Scoped Datasets URL.

Appears the working element ID requires `content-` prefixed to it, as seen on the live docs:

<img width="1229" alt="Screenshot 2023-06-24 at 15 20 11" src="https://github.com/pestphp/docs/assets/7256684/6bee196a-64a0-47c6-aad0-79eb7aeca367">

This PR is simply to apply that fix to the referenced URL.