### PR TITLE
Link to "Migrating from PHPUnit guide" corrected

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -37,4 +37,4 @@ Here is an example of the output displayed when running Pest in a new, fresh pro
 
 ---
 
-After the installation process is finished, you can enhance your developer experience while working with Pest by configuring your editor: [Editor Setup →](/docs/editor-setup). If you're migrating from PHPUnit, check out the [Migration Guide →](/docs/migration-from-phpunit).
+After the installation process is finished, you can enhance your developer experience while working with Pest by configuring your editor: [Editor Setup →](/docs/editor-setup). If you're migrating from PHPUnit, check out the [Migration Guide →](/docs/migrating-from-phpunit-guide).


### PR DESCRIPTION
I've noticed that there is an error 404 link on the Installation Page pointing to [Migration Guide →](https://pestphp.com/docs/migration-from-phpunit). Instead, it should be pointing to [Migration Guide →](https://pestphp.com/docs/migrating-from-phpunit-guide)