### PR TITLE
Update test-coverage.md

### DIFF
--- a/test-coverage.md
+++ b/test-coverage.md
@@ -13,11 +13,7 @@ Typically, the essential configuration for gathering code coverage is already pr
 
 ```xml
     ...
-    <coverage>
-        <include>
-            <directory suffix=".php">./app</directory>
-        </include>
-    </coverage>
+    <coverage/>
     ...
 ```
 


### PR DESCRIPTION
Fixes this warning which cancels the coverage report:

WARN  Test results may not be as expected because the XML configuration file did not pass validation:

  - Element 'include': This element is not expected.