### PR TITLE
Remove `--ansi` Option from BitBucket CI Example

### DIFF
--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -107,7 +107,7 @@ pipelines:
           name: Test
           script:
             - composer install --no-interaction --prefer-dist --optimize-autoloader
-            - ./vendor/bin/pest --ansi
+            - ./vendor/bin/pest
           caches:
             - composer
 ```


### PR DESCRIPTION
Related to: https://github.com/pestphp/docs/issues/200