### PR TITLE
Fixed broken link

### DIFF
--- a/arch-testing.md
+++ b/arch-testing.md
@@ -371,7 +371,7 @@ test('app')
     ->toOnlyBeUsedIn('App\Models');
 ```
 
-<a name="expect-ignoring"></a>
+<a name="modifier-ignoring"></a>
 ### `ignoring()`
 
 When defining your architecture rules, you can use the `ignoring()` method to exclude certain namespaces or classes that would otherwise be included in the rule definition.


### PR DESCRIPTION
Hey! I was just searching through the architecture docs looking for the `ignoring` modifier and noticed that the link to snap to that section looked a bit broken.

This seems to solve the issue, but apologies in advance if I've not done it right though 🙂