### PR TITLE
fix: resolve heading link for enum modifier

### DIFF
--- a/arch-testing.md
+++ b/arch-testing.md
@@ -359,7 +359,6 @@ test('app')
 ```
 
 <a name="modifier-enums"></a>
-
 ### `enums()`
 
 The `enums()` modifier allows you to restrict the expectation to only enums.


### PR DESCRIPTION
Currently the heading link is `#enums` as there is a gap between these.