### PR TITLE
docs: update deprecated `<coverage>` config usage

### DIFF
--- a/test-coverage.md
+++ b/test-coverage.md
@@ -13,11 +13,11 @@ Typically, the essential configuration for gathering code coverage is already pr
 
 ```xml
     ...
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">./app</directory>
         </include>
-    </coverage>
+    </source>
     ...
 ```
 


### PR DESCRIPTION
Closes #240