### PR TITLE
Using the good value instead of the key name

### DIFF
--- a/expectations.md
+++ b/expectations.md
@@ -985,7 +985,7 @@ The `sequence()` modifier can also be used with associative iterables. Each clos
 
 ```php
 expect(['hello' => 'world', 'foo' => 'bar', 'john' => 'doe'])->sequence(
-    fn ($value, $key) => $value->toEqual('hello'),
+    fn ($value, $key) => $value->toEqual('world'),
     fn ($value, $key) => $key->toEqual('foo'),
     fn ($value, $key) => $value->toBeString(),
 );


### PR DESCRIPTION
Hi, 

I found this small error and corrected it.

The key name was used instead of the value.