### PR TITLE
Plugin `pest-plugin-type-coverage`: Add new `--type-coverage-json` argument

### DIFF
--- a/type-coverage.md
+++ b/type-coverage.md
@@ -50,9 +50,11 @@ Just like code coverage, type coverage can also be enforced. To ensure any code 
 
 ## Different Formats
 
-Pest support reporting type coverage to a file:
+In additionm, Pest support reporting the type coverage to a specific file:
 
-- `--type-coverage-json=<file>`: Save the type coverage report in JSON format to a specified file.
+```bash
+./vendor/bin/pest --type-coverage --min=100 --type-coverage-json=my-report.json
+```
 
 ---
 

--- a/type-coverage.md
+++ b/type-coverage.md
@@ -50,7 +50,7 @@ Just like code coverage, type coverage can also be enforced. To ensure any code 
 
 ## Different Formats
 
-Pest support reporting type coverage to a file as well:
+Pest support reporting type coverage to a file:
 
 - `--type-coverage-json=<file>`: Save the type coverage report in JSON format to a specified file.
 

--- a/type-coverage.md
+++ b/type-coverage.md
@@ -52,7 +52,7 @@ Just like code coverage, type coverage can also be enforced. To ensure any code 
 
 Pest support reporting type coverage to a file as well:
 
-- `--coverage-clover=<file>`: Save the type coverage report in JSON format to a specified file.
+- `--type-coverage-json=<file>`: Save the type coverage report in JSON format to a specified file.
 
 ---
 

--- a/type-coverage.md
+++ b/type-coverage.md
@@ -48,6 +48,12 @@ Just like code coverage, type coverage can also be enforced. To ensure any code 
 ./vendor/bin/pest --type-coverage --min=100
 ```
 
+## Different Formats
+
+Pest support reporting type coverage to a file as well:
+
+- `--coverage-clover=<file>`: Save the type coverage report in JSON format to a specified file.
+
 ---
 
 In the chapter, we have discussed Pest's Type Coverage plugin and how it can be used to measure the percentage of code that is covered by type declarations. In the following chapter, we explain how can you use Snapshots to test your code: [Snapshot Testing](/docs/snapshot-testing)


### PR DESCRIPTION
Added "Different formats" documentation, attempting to keep it as similar as the `code-coverage.md` file.