### PR TITLE
Update PHPUnit doc link

### DIFF
--- a/writing-tests.md
+++ b/writing-tests.md
@@ -98,7 +98,7 @@ test('sum', function () {
 });
 ```
 
-You can find the full documentation for PHPUnit's assertion API on the PHPUnit website: [docs.phpunit.de/en/10.5/assertions.html](https://docs.phpunit.de/en/10.5/assertions.html)
+You can find the full documentation for PHPUnit's assertion API on the PHPUnit website: [docs.phpunit.de/en/11.0/assertions.html](https://docs.phpunit.de/en/11.0/assertions.html)
 
 ---
 


### PR DESCRIPTION
Current link leads to 404 page. The working URL is now https://docs.phpunit.de/en/11.0/assertions.html.