### PR TITLE
Fix `float` expectation example

### DIFF
--- a/writing-tests.md
+++ b/writing-tests.md
@@ -71,7 +71,7 @@ describe('sum', function () {
     it('may sum floats', function () {
        $result = sum(1.5, 2.5);
 
-       expect($result)->toBe(4);
+       expect($result)->toBe(4.0);
     });
 });
 ```


### PR DESCRIPTION
I saw _rominronin_ reported this error on Discord and you asked a PR to fix it in February, but he didn't make it, so I'm here :)

On [writing tests](https://pestphp.com/docs/writing-tests)  page, the float example is wrong, so I fixed it :
```diff
describe('sum', function () {
   it('may sum integers', function () {
       $result = sum(1, 2);
 
       expect($result)->toBe(3);
    });
 
    it('may sum floats', function () {
       $result = sum(1.5, 2.5);
 
-      expect($result)->toBe(4);
+      expect($result)->toBe(4.0);
    });
});
```