### PR TITLE
Add explanation of dataset name interpolation (Pest PR #1146)

### DIFF
--- a/datasets.md
+++ b/datasets.md
@@ -47,6 +47,12 @@ If a key is added, Pest will use the key when generating the description for the
     <img src="/assets/img/datasets-named.webp?1" style="--lines: 2" />
 </div>
 
+If the test name includes `:dataset`, the description will be interpolated into the test name at that location.
+
+<div class="code-snippet">
+    <img src="/assets/img/datasets-interpolated.webp?1" style="--lines: 2" />
+</div>
+
 It is important to notice that when using `closures` in your dataset, you must declare the arguments type in the closure passed to the test function.
 
 ```php


### PR DESCRIPTION
This PR adds documentation for the feature added [in this PR](https://github.com/pestphp/pest/pull/1146)

This change requires an image to be added. I'm not sure how the webp files referenced in the documentation are generated or stored. It does not seem to happen in repo.

This new addition requires a new image, the same size as the `datasets-named`.

You could generate it with the following test

```php
it('validates the :dataset field', function ($field) {
    expect(true)->toBeTrue();
})->with([
    'first_name' => null,
    'email' => null,
]);
```

For example:
![CleanShot 2024-09-10 at 16 57 56@2x](https://github.com/user-attachments/assets/e0d3ad49-2dd9-4ea5-950d-550bdb5e97d4)

Thanks as always!