### PR TITLE
Remove All keyword from documentation expectations

### DIFF
--- a/arch-testing.md
+++ b/arch-testing.md
@@ -59,8 +59,8 @@ Granular expectations allow you to define specific architectural rules for your 
 - [`toExtendNothing()`](#expect-toExtendNothing)
 - [`toImplement()`](#expect-toImplement)
 - [`toImplementNothing()`](#expect-toImplementNothing)
-- [`toHaveAllMethodsDocumented()`](#expect-toHaveAllMethodsDocumented)
-- [`toHaveAllPropertiesDocumented()`](#expect-toHaveAllPropertiesDocumented)
+- [`toHaveMethodsDocumented()`](#expect-toHaveMethodsDocumented)
+- [`toHavePropertiesDocumented()`](#expect-toHavePropertiesDocumented)
 - [`toHaveAttribute()`](#expect-toHaveAttribute)
 - [`toHaveFileSystemPermissions()`](#expect-toHaveFileSystemPermissions)
 - [`toHaveLineCountLessThan()`](#expect-toHaveLineCountLessThan)
@@ -289,26 +289,26 @@ arch('app')
     ->toImplementNothing();
 ```
 
-<a name="expect-toHaveAllMethodsDocumented"></a>
-### `toHaveAllMethodsDocumented()`
+<a name="expect-toHaveMethodsDocumented"></a>
+### `toHaveMethodsDocumented()`
 
-The `toHaveAllMethodsDocumented()` method may be used to ensure that all methods within a given namespace are documented.
+The `toHaveMethodsDocumented()` method may be used to ensure that all methods within a given namespace are documented.
 
 ```php
 arch('app')
     ->expect('App')
-    ->toHaveAllMethodsDocumented();
+    ->toHaveMethodsDocumented();
 ```
 
-<a name="expect-toHaveAllPropertiesDocumented"></a>
-### `toHaveAllPropertiesDocumented()`
+<a name="expect-toHavePropertiesDocumented"></a>
+### `toHavePropertiesDocumented()`
 
-The `toHaveAllPropertiesDocumented()` method may be used to ensure that all properties within a given namespace are documented.
+The `toHavePropertiesDocumented()` method may be used to ensure that all properties within a given namespace are documented.
 
 ```php
 arch('app')
     ->expect('App')
-    ->toHaveAllPropertiesDocumented();
+    ->toHavePropertiesDocumented();
 ```
 
 <a name="expect-toHaveAttribute"></a>

--- a/pest3-now-available.md
+++ b/pest3-now-available.md
@@ -19,7 +19,7 @@ Below, we'll cover all the juicy details about this release. And as usual, you c
 - **[Arch Presets](#arch-presets)**: A set of predefined rules that you can use to test your application's architecture.
 - **[Team Management](#team-management)**: A new feature that allows you to manage tasks and todos with your team directly from the console.
 - **[New Configuration API](#new-configuration-api)**: A new configuration API that is more intuitive and easier to use.
-- **[More Architectural Testing Improvements](#more-architectural-testing-improvements)**: `toHaveAllMethodsDocumented`, `->not->toHaveProtectedMethods`, and more.
+- **[More Architectural Testing Improvements](#more-architectural-testing-improvements)**: `toHaveMethodsDocumented`, `->not->toHaveProtectedMethods`, and more.
 - **[And Much More...](#miscellaneous-improvements)**: Constants in Type Coverage, static analysis improvements, and more.
 
 <a name="mutation-testing"></a>
@@ -264,8 +264,8 @@ And of course, any method that was available on the `uses()` API, like `->before
 
 Again, Pest comes with a bunch of new architectural expectations and improvements. Some of them are already being used in the new Arch Presets, but you can use them individually as well.
 
-- [`toHaveAllMethodsDocumented()`](/docs/arch-testing#expect-toHaveAllMethodsDocumented) - Asserts that a class has all its methods documented.
-- [`toHaveAllPropertiesDocumented()`](/docs/arch-testing#expect-toHaveAllPropertiesDocumented) - Asserts that a class has all its properties documented.
+- [`toHaveMethodsDocumented()`](/docs/arch-testing#expect-toHaveMethodsDocumented) - Asserts that a class has all its methods documented.
+- [`toHavePropertiesDocumented()`](/docs/arch-testing#expect-toHavePropertiesDocumented) - Asserts that a class has all its properties documented.
 - [`toHaveFileSystemPermissions()`](/docs/arch-testing#expect-toHaveFileSystemPermissions) - Asserts that a file has the expected file system permissions.
 - [`toHaveLineCountLessThan`](/docs/arch-testing#expect-toHaveLineCountLessThan) - Asserts that a file has less than a given number of lines.
 - [`toHaveMethods()`](/docs/arch-testing#expect-toHaveMethod) - Asserts that a class has the expected methods.


### PR DESCRIPTION
The actual assertion no longer uses the All keyword when asserting that a method or property is documented, this just fixes the docs to be in line with the [src/Expectation.php](https://github.com/pestphp/pest/blob/3.x/src/Expectation.php) class.