### PR TITLE
Update mutation-testing.md

### DIFF
--- a/mutation-testing.md
+++ b/mutation-testing.md
@@ -187,6 +187,31 @@ public function rules(): array
 }
 ```
 
+> [!NOTE]
+> Lines that aren't considered executable will always be marked as UNCOVERED.
+
+For such cases, like with model properties, you may apply `@pest-mutate-ignore` in the following way. 
+
+```php
+/**
+ * @pest-mutate-ignore
+ */
+protected $guarded = [
+    'id',
+    'created_at',
+    'updated_at',
+];
+
+/**
+ * @pest-mutate-ignore
+ */
+protected $hidden = [
+    'id',
+    'created_at',
+    'updated_at',
+];
+```
+
 <a name="id"></a>
 ### `--id`
 


### PR DESCRIPTION
This adds a note to use `@pest-mutate-ignore` on non-executable code.

**Important**: Please verify if GitHub Markdown Alerts get parsed properly in the docs site before merging this in.

Related Issue: https://github.com/pestphp/pest/issues/1231