### PR TITLE
docs: add two new examples to undestand `->toBeDigits`

### DIFF
--- a/expectations.md
+++ b/expectations.md
@@ -502,6 +502,8 @@ This expectation ensures that `$value` contains only digits.
 expect($year)->toBeDigits();
 expect(15)->toBeDigits();
 expect('15')->toBeDigits();
+expect(0.123)->not->toBeDigits();
+expect('0.123')->not->toBeDigits();
 ```
 
 <a name="expect-toBeObject"></a>


### PR DESCRIPTION
Hello everybody,

This PR proposes adding a simple example for a expect testing `toBeDigits()`.

The idea is motivated by my misunderstanding for the test expectation.