### PR TITLE
Grouping Tests: Fix syntax in code example

### DIFF
--- a/grouping-tests.md
+++ b/grouping-tests.md
@@ -41,7 +41,7 @@ If you want to assign a group to a describe block, you can do so by chaining the
 
 ```php
 describe('home', function () {
-    test('main page', function ()
+    test('main page', function () {
         //
     });
 })->group('feature');


### PR DESCRIPTION
This pull request fixes a syntax issue in a code example on the "[Grouping Tests](https://pestphp.com/docs/grouping-tests)" page.

![CleanShot 2024-11-23 at 01 41 20@2x](https://github.com/user-attachments/assets/68e5e703-8398-4e48-ae0d-542c63e4101c)
