### PR TITLE
Fix typo in grouping-tests

### DIFF
--- a/grouping-tests.md
+++ b/grouping-tests.md
@@ -41,7 +41,7 @@ If you want to assign a group to a describe block, you can do so by chaining the
 
 ```php
 describe('home', function () {
-    test('main page', function ()
+    test('main page', function () {
         //
     });
 })->group('feature');


### PR DESCRIPTION
Hey,

This PR fixes a small typo in the `grouping-test.md` file.