### PR TITLE
Fix incorrect team management link

### DIFF
--- a/pest3-now-available.md
+++ b/pest3-now-available.md
@@ -234,7 +234,7 @@ Finally, you can view todos separately from the rest of your test suite by inclu
 ./vendor/bin/pest --todos --assignee=taylor # or --issue=123
 ```
 
-There is so much more to explore with Team Management, you can learn more about it in our [Team Management](docs/team-management) section.
+There is so much more to explore with Team Management, you can learn more about it in our [Team Management](/docs/team-management) section.
 
 <a name="nested-describes"></a>
 ## Nested Describes

--- a/pest3-now-available.md
+++ b/pest3-now-available.md
@@ -234,7 +234,7 @@ Finally, you can view todos separately from the rest of your test suite by inclu
 ./vendor/bin/pest --todos --assignee=taylor # or --issue=123
 ```
 
-There is so much more to explore with Team Management, you can learn more about it in our [Team Management](#team-management) section.
+There is so much more to explore with Team Management, you can learn more about it in our [Team Management](docs/team-management) section.
 
 <a name="nested-describes"></a>
 ## Nested Describes


### PR DESCRIPTION
The link for team management was incorrect and just linked to the section of the same page.