### PR TITLE
Add docs for todo() method

### DIFF
--- a/skipping-tests.md
+++ b/skipping-tests.md
@@ -77,6 +77,16 @@ beforeEach(function () {
 })->skip();
 ```
 
+## Creating todos
+
+You might want to add a couple of empty tests to make sure you don't forget to add them later. The `todo()` can be useful in this situation.
+
+```php
+it('has home', function () {
+    //
+})->todo();
+```
+
 ---
 
 As your codebase expands, it's advisable to consider enhancing the speed of your test suite. To assist you with that, we offer comprehensive documentation on optimizing your test suite: [Optimizing Tests](/docs/optimizing-tests)


### PR DESCRIPTION
The announcement of Pest 2 mentions the ->todo() method, but links to a section of the docs that doesn't exist.

Other pages in the docs seem to use #content-topic for links, connected to a ## topic.
As such, I tried to match the link in the Pest 2 announcement, linking to #content-creating-todos:
https://pestphp.com/docs/announcing-pest2