### PR TITLE
add note about arch testing within test blocks

### DIFF
--- a/arch-testing.md
+++ b/arch-testing.md
@@ -30,7 +30,7 @@ arch()->preset()->php();
 arch()->preset()->security()->ignoring('md5');
 ```
 
-## Note: arch() is not to be used within a test block
+## Note: arch() is Not to be Used Within a Test Block
 
 Calls to arch() are meant to be run outside of test blocks. 
 

--- a/arch-testing.md
+++ b/arch-testing.md
@@ -30,6 +30,28 @@ arch()->preset()->php();
 arch()->preset()->security()->ignoring('md5');
 ```
 
+## Note: arch() is not to be used within a test block
+
+Calls to arch() are meant to be run outside of test blocks. 
+
+For example, the following **will not work:**
+```php
+test('test arch test', function () {
+    arch()...
+}
+
+it('test arch test', function() {
+    arch()...
+}
+```
+
+You should define your arch test in a Test.php file like so:
+```php
+arch()...
+```
+
+## Methods and Expectations
+
 Now, let's dive into the various methods and modifiers available for architectural testing. In this section, you will learn:
 
 - [Expectations](#expectations): Allows to specify granular architectural rules.

--- a/arch-testing.md
+++ b/arch-testing.md
@@ -50,7 +50,7 @@ You should define your arch test in a Test.php file like so:
 arch()...
 ```
 
-## Methods and Expectations
+## Methods, Expectations and Modifiers
 
 Now, let's dive into the various methods and modifiers available for architectural testing. In this section, you will learn:
 


### PR DESCRIPTION
This pull request includes an update to the `arch-testing.md` documentation to clarify the usage of the `arch()` function. The most important changes include adding a new note about the correct usage of `arch()` and providing examples of what will not work versus what should be done.

Documentation updates:

* [`arch-testing.md`](diffhunk://#diff-8e572ea22984fe2642b770dfe932899a459058a94b3c520882cb6e04aafa4140R33-R54): Added a section titled "Note: arch() is Not to be Used Within a Test Block" to clarify that calls to `arch()` should be run outside of test blocks, and provided examples of incorrect and correct usage.