### PR TITLE
Add valid usage example for `each`

### DIFF
--- a/expectations.md
+++ b/expectations.md
@@ -897,6 +897,7 @@ The `each()` modifier allows you to create an expectation on each item of the gi
 expect([1, 2, 3])->each->toBeInt();
 expect([1, 2, 3])->each->not->toBeString();
 expect([1, 2, 3])->each(fn ($number) => $number->toBeLessThan(4));
+expect([1, 2, 3])->each(fn ($number, $key) => $number->toEqual($key + 1));
 ```
 
 <a name="expect-json"></a>


### PR DESCRIPTION
As requested here: https://github.com/pestphp/pest/issues/1413

This change only applies to the 3.x branch. If accepted, it should also be applied to the 4.x branch. I can do that if you ping me.