### PR TITLE
[4.x] fix: bcrypt() not needed on password

### DIFF
--- a/browser-testing.md
+++ b/browser-testing.md
@@ -25,7 +25,7 @@ it('may sign in the user', function () {
 
     User::factory()->create([ // assumes RefreshDatabase trait is used on Pest.php...
         'email' => 'nuno@laravel.com',
-        'password' => bcrypt('password'),
+        'password' => 'password',
     ]);
 
     $page = visit('/')->on()->mobile()->firefox();


### PR DESCRIPTION
A tiny tweak. The `User` password field is hashed and fillable by default.

```
> User::factory()->create(['name' => 'Foo Bar', 'email' => 'foobar@bar.com', 'password' => 'password']);
= App\Models\User {#6235
    name: "Foo Bar",
    email: "foobar@bar.com",
    email_verified_at: "2025-08-21 16:03:43",
    #password: "$2y$12$hrgAUJvdNYqs6AMetC/.c.X6AicAJIlQ7s/uGKdZAb6Bc.rySIsZ2",
    #remember_token: "tokK0VCbRy",
    updated_at: "2025-08-21 16:03:43",
    created_at: "2025-08-21 16:03:43",
    id: 1,
  }
```