### PR TITLE
Remove return from script() example

### DIFF
--- a/browser-testing.md
+++ b/browser-testing.md
@@ -992,7 +992,7 @@ $value = $page->value('input[name=email]');
 The `script` method executes a script in the context of the page:
 
 ```php
-$result = $page->script('return document.title');
+$result = $page->script('document.title');
 ```
 
 <a name="content"></a>


### PR DESCRIPTION
Running "$result = $page->script('return document.title');" throws an error: "SyntaxError: Illegal return statement"

After removing the return, everything works as intended and $result is filled with the correct value.