### PR TITLE
Fix typo in v4 shard example

### DIFF
--- a/pest-v4-is-here-now-with-browser-testing.md
+++ b/pest-v4-is-here-now-with-browser-testing.md
@@ -134,7 +134,7 @@ name: Tests (Shard ${{ matrix.shard }}/4)
 
 steps:
   - name: Run tests
-    run: pest --parallel --shard ${{ matrix.shard }}/5
+    run: pest --parallel --shard ${{ matrix.shard }}/4
 ```
 
 ## Type Coverage Is Much Faster


### PR DESCRIPTION
The example run command in the docs is currently set to run 5 shards; however, the config only has 4 shards.
This PR updates the example to match the number of shards in the config.