### PR TITLE
ci: fix lychee link checker

### DIFF
--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -13,8 +13,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: 🔗 Check Links
-        uses: lycheeverse/lychee-action@v1.10.0
+      - name: Restore lychee cache
+        uses: actions/cache@v4
         with:
-          fail: true
-          args: --config .github/workflows/lychee.toml './**/*.md'
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: 🔗 Check Links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          jobSummary: true
+          args: --base . --cache --max-cache-age 1d --config .github/workflows/lychee.toml './**/*.md'

--- a/.github/workflows/lychee.toml
+++ b/.github/workflows/lychee.toml
@@ -88,10 +88,13 @@ include_verbatim = false
 glob_ignore_case = false
 
 # Exclude URLs and mail addresses from checking (supports regex).
-#exclude = [ '.*\.github.com\.*' ]
 # receiving forbidden but valid link, receiving timeout but valid link
-exclude = ['https://opensource.org/licenses/MIT', 'https://twitter.com/pestphp', '^https://laracasts.com/series/(pest-driven-laravel|pest-from-scratch)$']
-
+exclude = [
+    'https://opensource.org/licenses/MIT',
+    'https://twitter.com/pestphp',
+    '^https://laracasts.com/series/(pest-driven-laravel|pest-from-scratch)$',
+    '^https://www.linkedin.com/learning/.*$',
+]
 
 # Exclude these filesystem paths from getting checked.
 #exclude_path = ["file/path/to/Ignore", "./other/file/path/to/Ignore"]


### PR DESCRIPTION
This updates to Lychee Action 2.x, and adds LinkedIn Learning as an excluded URL for checking, as they seem to return 404 to scrapers.