### PR TITLE
Add toHaveSuspiciousCharacters documentation

### DIFF
--- a/arch-testing.md
+++ b/arch-testing.md
@@ -78,6 +78,7 @@ Granular expectations allow you to define specific architectural rules for your 
 - [`toHavePublicMethods()`](#expect-toHavePublicMethods)
 - [`toHavePrefix()`](#expect-toHavePrefix)
 - [`toHaveSuffix()`](#expect-toHaveSuffix)
+- [`toHaveSuspiciousCharacters()`](#expect-toHaveSuspiciousCharacters)
 - [`toHaveConstructor()`](#expect-toHaveConstructor)
 - [`toHaveDestructor()`](#expect-toHaveDestructor)
 - [`toOnlyImplement()`](#expect-toOnlyImplement)
@@ -458,6 +459,19 @@ arch('app')
     ->toHaveSuffix('Controller');
 ```
 
+<a name="expect-toHaveSuspiciousCharacters"></a>
+### `toHaveSuspiciousCharacters()`
+
+The `toHaveSuspiciousCharacters()` method may be used to help you identify potential suspicious characters in your code.
+
+```php
+arch('app')
+    ->expect('App\Http\Controllers')
+    ->not->toHaveSuspiciousCharacters();
+```
+
+This expectation requires the `intl` PHP extension.
+
 <a name="expect-toHaveConstructor"></a>
 ### `toHaveConstructor()`
 
@@ -619,7 +633,9 @@ It avoids the usage of `die`, `var_dump`, and similar functions, and ensures you
 arch()->preset()->php();
 ```
 
-You may find all the expectations included in the `php` preset below in our [source code](https://github.com/pestphp/pest/blob/3.x/src/ArchPresets/Php.php).
+You may find all the expectations included in the `php` preset below in our [source code](https://github.com/pestphp/pest/blob/4.x/src/ArchPresets/Php.php).
+
+This preset requires the `intl` PHP extension.
 
 <a name="preset-security"></a>
 ### `security`

--- a/pest-v4-is-here-now-with-browser-testing.md
+++ b/pest-v4-is-here-now-with-browser-testing.md
@@ -193,7 +193,7 @@ it('does not run on CI', function () {
 ### Miscellaneous Improvements
 
 - You may now use `skipLocally()` or `skipOnCi` to conditionally skip tests based on the environment.
-- The `not->toHaveSuspiciousCharacters()` arch expectation has been added to help you identify potential suspicious characters in your code. This arch expectation is now enabled by default on the `php` arch preset.
+- The `not->toHaveSuspiciousCharacters()` arch expectation has been added to help you identify potential suspicious characters in your code. This arch expectation is now enabled by default on the `php` arch preset. This expectation requires the `intl` PHP extension.
 - The expectation `toBeSlug` has been added to help you validate that a string is a valid slug.
 
 ### On Top of PHPUnit 12


### PR DESCRIPTION
Notes that the `intl` PHP extension is required and updates the source code URL to point to the 4.x branch, which includes the new expectation.

**Pages impacted**:
- https://pestphp.com/docs/arch-testing
- https://pestphp.com/docs/pest-v4-is-here-now-with-browser-testing

| Page | Before | After |
| :--- | :--- | :--- |
| https://pestphp.com/docs/arch-testing#content-expectations | <img width="694" height="600" alt="Screenshot 2025-09-11 at 5 01 38 PM" src="https://github.com/user-attachments/assets/41df2569-9584-4481-ab54-d1a1a7a65330" /> | <img width="754" height="644" alt="Screenshot 2025-09-11 at 5 02 11 PM" src="https://github.com/user-attachments/assets/f21f9cbd-9f99-49ac-adaa-a2c29a5caba5" /> |
| https://pestphp.com/docs/arch-testing#content-toHaveSuspiciousCharacters | <img width="735" height="633" alt="Screenshot 2025-09-11 at 5 04 39 PM" src="https://github.com/user-attachments/assets/c46b5f62-bcbb-4c96-81dc-cba91e5fbbc2" /> | <img width="716" height="936" alt="Screenshot 2025-09-11 at 5 08 23 PM" src="https://github.com/user-attachments/assets/a328f148-e195-4f61-86fd-4e8d1b9af243" /> |
| https://pestphp.com/docs/arch-testing#content-php | <img width="712" height="386" alt="Screenshot 2025-09-11 at 5 11 02 PM" src="https://github.com/user-attachments/assets/3ad38e24-bf6e-4324-8ed6-04f6adfc32c2" /> | <img width="715" height="434" alt="Screenshot 2025-09-11 at 5 11 43 PM" src="https://github.com/user-attachments/assets/af13c766-f069-44dc-b285-c1ffd275bdf0" /> |
| https://pestphp.com/docs/pest-v4-is-here-now-with-browser-testing#content-miscellaneous-improvements | <img width="698" height="310" alt="Screenshot 2025-09-11 at 5 13 39 PM" src="https://github.com/user-attachments/assets/a3b4755e-a7b1-4d1a-beed-201cc7e761e0" /> | <img width="696" height="336" alt="Screenshot 2025-09-11 at 5 14 05 PM" src="https://github.com/user-attachments/assets/3f62bc4f-8673-46f3-8f1d-0a43e217032c" /> |

Relates to https://github.com/pestphp/pest/issues/1509