### PR TITLE
Update docs for Test Coverage CLI options to reflect expected usage

### DIFF
--- a/test-coverage.md
+++ b/test-coverage.md
@@ -91,7 +91,7 @@ Pest supports various code coverage report formats:
 - `--coverage-crap4j <file>`: Save the code coverage report in Crap4J XML format to a specified file.
 - `--coverage-html <dir>`: Save the code coverage report in HTML format to a specified directory.
 - `--coverage-php <file>`: Serialize the code coverage data and save it to a specified file.
-- `--coverage-text <file>`: Save the code coverage report in text format to a specified file. (Default: php://stdout)
+- `--coverage-text=<file>`: Save the code coverage report in text format to a specified file. (Default: php://stdout)
 - `--coverage-xml <dir>`: Save the code coverage report in XML format to a specified directory.
 
 ---


### PR DESCRIPTION
The documentation for configuring [Test Coverage formats](https://pestphp.com/docs/test-coverage#content-different-formats) on the PestPHP website differs from the `--help` command output.

Specifically, the `--coverage-text` option expects a file name to be provided using the syntax `--coverage-text=[file]` rather than what the website documentation shows (`--coverage-text <file>`).

This pull requests updates the PestPHP docs to reflect the actual CLI usage, indicating the file needs to be provided after the option using an equals sign (`=`).

**Command Line Usage**
```
--coverage-text=[file]
```

**Website Documentation**
```
--coverage-text <file>
```
 
<img width="1201" height="356" alt="Screenshot 2026-05-14 at 8 34 59 AM" src="https://github.com/user-attachments/assets/da6e5731-2b73-46ad-9d2b-d5b0358cd6c9" />
