### PR TITLE
Add toBeUlid docs

### DIFF
--- a/browser-testing.md
+++ b/browser-testing.md
@@ -917,6 +917,12 @@ The `click` method clicks the link with the given text:
 $page->click('Login');
 ```
 
+You may also pass options:
+
+```php
+$page->click('#button', options: ['clickCount' => 2]);
+```
+
 <a name="text"></a>
 ### text
 

--- a/browser-testing.md
+++ b/browser-testing.md
@@ -917,12 +917,6 @@ The `click` method clicks the link with the given text:
 $page->click('Login');
 ```
 
-You may also pass options:
-
-```php
-$page->click('#button', options: ['clickCount' => 2]);
-```
-
 <a name="text"></a>
 ### text
 

--- a/expectations.md
+++ b/expectations.md
@@ -107,6 +107,7 @@ With the Pest expectation API, you have access to an extensive collection of ind
 - [`toHaveSameSize()`](#expect-toHaveSameSize)
 - [`toBeUrl()`](#expect-toBeUrl)
 - [`toBeUuid()`](#expect-toBeUuid)
+- [`toBeUlid()`](#expect-toBeUlid)
 
 </div>
 
@@ -837,6 +838,15 @@ This expectation ensures that `$value` is an UUID.
 
 ```php
 expect('ca0a8228-cdf6-41db-b34b-c2f31485796c')->toBeUuid();
+```
+
+<a name="expect-toBeUlid"></a>
+### `toBeUlid()`
+
+This expectation ensures that `$value` is a ULID.
+
+```php
+expect('01ARZ3NDEKTSV4RRFFQ69G5FAV')->toBeUlid();
 ```
 
 ---


### PR DESCRIPTION
## What
Adds documentation for the new `toBeUlid()` expectation.

## Why
pestphp/pest#1726 introduced `toBeUlid()`, and the docs should reflect the new expectation alongside the existing `toBeUuid()` entry.

## Impact
- Adds `toBeUlid()` to the expectations index
- Documents `toBeUlid()` with a matching example in `expectations.md`

## Validation
- Reviewed the existing expectation docs structure and mirrored the `toBeUuid()` pattern
