### PR TITLE
docs: add toBeEmail() expectation

### DIFF
--- a/browser-testing.md
+++ b/browser-testing.md
@@ -917,6 +917,12 @@ The `click` method clicks the link with the given text:
 $page->click('Login');
 ```
 
+You may also pass options:
+
+```php
+$page->click('#button', options: ['clickCount' => 2]);
+```
+
 <a name="text"></a>
 ### text
 

--- a/browser-testing.md
+++ b/browser-testing.md
@@ -917,12 +917,6 @@ The `click` method clicks the link with the given text:
 $page->click('Login');
 ```
 
-You may also pass options:
-
-```php
-$page->click('#button', options: ['clickCount' => 2]);
-```
-
 <a name="text"></a>
 ### text
 

--- a/expectations.md
+++ b/expectations.md
@@ -105,6 +105,7 @@ With the Pest expectation API, you have access to an extensive collection of ind
 - [`toHaveCamelCaseKeys()`](#expect-toHaveCamelCaseKeys)
 - [`toHaveStudlyCaseKeys()`](#expect-toHaveStudlyCaseKeys)
 - [`toHaveSameSize()`](#expect-toHaveSameSize)
+- [`toBeEmail()`](#expect-toBeEmail)
 - [`toBeUrl()`](#expect-toBeUrl)
 - [`toBeUuid()`](#expect-toBeUuid)
 
@@ -819,6 +820,15 @@ This expectation ensures that the size of `$value` and the provided iterable are
 
 ```php
 expect(['foo', 'bar'])->toHaveSameSize(['baz', 'bazz']);
+```
+
+<a name="expect-toBeEmail"></a>
+### `toBeEmail()`
+
+This expectation ensures that `$value` is a valid email address.
+
+```php
+expect('user@example.com')->toBeEmail();
 ```
 
 <a name="expect-toBeUrl"></a>


### PR DESCRIPTION
## Summary

- Documents new `toBeEmail()` expectation added in pestphp/pest#1735
- Added to TOC and inserted doc section alphabetically before `toBeUrl()`
- Follows existing pattern: anchor, h3, one-line description, PHP example

## Test plan

- [ ] Verify anchor link in TOC resolves correctly
- [ ] Confirm placement is alphabetically correct between `toHaveSameSize()` and `toBeUrl()`